### PR TITLE
Added callback for QLab replies

### DIFF
--- a/QLabKit.xcodeproj/project.pbxproj
+++ b/QLabKit.xcodeproj/project.pbxproj
@@ -309,7 +309,8 @@
 				92F3EA41178B1DA300A4C617 /* NSString+F53OSCString.m */,
 				92F3EA42178B1DA300A4C617 /* README.markdown */,
 			);
-			path = F53OSC;
+			name = F53OSC;
+			path = "../../../Space Map/F53OSC-master";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/lib/QLKClient.m
+++ b/lib/QLKClient.m
@@ -165,6 +165,11 @@
   
   if ([message isReply]) {    
     id data = message.response;
+      
+  NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:message, QLKReplyMsg, nil];
+  [[NSNotificationCenter defaultCenter] postNotificationName:QLKWorkspaceGotReply
+                                                      object:nil
+                                                    userInfo:dict];
     
     // Special case, want to update cue properties
     if ([message isReplyCueUpdate]) {

--- a/lib/QLKDefines.h
+++ b/lib/QLKDefines.h
@@ -40,3 +40,6 @@ typedef void (^QLKMessageHandlerBlock)(id data);
 extern NSString * const QLKBonjourTCPServiceType;
 extern NSString * const QLKBonjourUDPServiceType;
 extern NSString * const QLKBonjourServiceDomain;
+extern NSString * const QLKWorkspaceGotReply;
+
+#define QLKReplyMsg @"QLKReplyMsg"

--- a/lib/QLKDefines.m
+++ b/lib/QLKDefines.m
@@ -30,3 +30,4 @@
 NSString * const QLKBonjourTCPServiceType = @"_qlab._tcp.";
 NSString * const QLKBonjourUDPServiceType = @"_qlab._udp.";
 NSString * const QLKBonjourServiceDomain = @"local.";
+NSString * const QLKWorkspaceGotReply = @"QLKGotReply";

--- a/lib/QLKWorkspace.h
+++ b/lib/QLKWorkspace.h
@@ -111,6 +111,7 @@ extern NSString * const QLKWorkspaceDidChangePlaybackPositionNotification;
 - (void)cue:(QLKCue *)cue updateFullScreen:(BOOL)fullScreen;
 - (void)cue:(QLKCue *)cue updateTranslationX:(CGFloat)originX;
 - (void)cue:(QLKCue *)cue updateTranslationY:(CGFloat)originY;
+- (void)cue:(QLKCue *)cue updateTargetID:(int) uid;
 - (void)cue:(QLKCue *)cue updateScaleX:(CGFloat)scaleX;
 - (void)cue:(QLKCue *)cue updateScaleY:(CGFloat)scaleY;
 - (void)cue:(QLKCue *)cue updateRotationX:(CGFloat)rotationX; 

--- a/lib/QLKWorkspace.m
+++ b/lib/QLKWorkspace.m
@@ -506,6 +506,11 @@ NSString * const QLKWorkspaceDidChangePlaybackPositionNotification = @"QLKWorksp
   [self.client sendMessage:@(stop) toAddress:[self addressForCue:cue action:@"stopTargetWhenSliceEnds"]];
 }
 
+- (void)cue:(QLKCue *)cue updateTargetID:(int) uid
+{
+  [self.client sendMessage:@(uid) toAddress:[self addressForCue:cue action:@"targetId"]];
+}
+
 #pragma mark - OSC Video methods
 
 - (void)cue:(QLKCue *)cue updateSurfaceID:(NSInteger)surfaceID

--- a/lib/QLKWorkspace.m
+++ b/lib/QLKWorkspace.m
@@ -508,7 +508,7 @@ NSString * const QLKWorkspaceDidChangePlaybackPositionNotification = @"QLKWorksp
 
 - (void)cue:(QLKCue *)cue updateTargetID:(int) uid
 {
-  [self.client sendMessage:@(uid) toAddress:[self addressForCue:cue action:@"targetId"]];
+  [self.client sendMessage:@(uid) toAddress:[self addressForCue:cue action:@"cueTargetId"]];
 }
 
 #pragma mark - OSC Video methods


### PR DESCRIPTION
When creating new cues (eg: "/new fade"), QLab will send back the new cues id.  The added code posts a notification for any "reply"'s from QLab.