### PR TITLE
remove ".qlab4" for workspace.nameWithoutPathExtension

### DIFF
--- a/lib/QLKWorkspace.h
+++ b/lib/QLKWorkspace.h
@@ -72,7 +72,7 @@ extern NSString * const QLKQLabDidUpdatePreferencesNotification;
 // Name of this workspace
 @property (copy, nonatomic, readonly)               NSString *name;
 
-// Name without the ".cues" extension, for cleaner presentation
+// Name without the ".cues" or ".qlab4" extension, for cleaner presentation
 @property (copy, nonatomic, readonly)               NSString *nameWithoutPathExtension;
 
 // A unique internal ID

--- a/lib/QLKWorkspace.m
+++ b/lib/QLKWorkspace.m
@@ -305,7 +305,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *) nameWithoutPathExtension
 {
-    if ( [self.name.lowercaseString.pathExtension isEqualToString:@"cues"] )
+    if ( [self.name.lowercaseString.pathExtension isEqualToString:@"cues"]  ||
+         [self.name.lowercaseString.pathExtension isEqualToString:@"qlab4"])
         return self.name.stringByDeletingPathExtension;
     else
         return self.name;


### PR DESCRIPTION
Big ol' change here...maybe there is a reason that it isn't removed and just `.cues` is